### PR TITLE
New Neon implementation: use SMLAL and SMLAL2

### DIFF
--- a/app/src/main/cpp/CpuThreadControl.cpp
+++ b/app/src/main/cpp/CpuThreadControl.cpp
@@ -25,5 +25,6 @@ unsigned int GetBigCoreAffinity()
 {
 	int coreCount = (int)sysconf(_SC_NPROCESSORS_CONF);
 	__android_log_print(ANDROID_LOG_INFO, "NeonIntrinsics", "CPU Core count = %d\n", coreCount);
+	// Return mask containing one (last) core which should be the biggest
 	return 1 << (coreCount - 1);
 }

--- a/app/src/main/cpp/DotProd.cpp
+++ b/app/src/main/cpp/DotProd.cpp
@@ -194,6 +194,69 @@ int dotProductNeon4(short* inputArray1, short* inputArray2, short len)
     return result;
 }
 
+int dotProductNeon6(short* inputArray1, short* inputArray2, short len)
+{
+    const int elementsPerIteration = 24;
+    int iterations = len / elementsPerIteration;
+
+    // 4-element vectors of zeroes to accumulate partial results within the unrolled loop
+    int32x4_t partialSum1 = vdupq_n_s32(0);
+    int32x4_t partialSum2 = vdupq_n_s32(0);
+    int32x4_t partialSum3 = vdupq_n_s32(0);
+    int32x4_t partialSum4 = vdupq_n_s32(0);
+    int32x4_t partialSum5 = vdupq_n_s32(0);
+    int32x4_t partialSum6 = vdupq_n_s32(0);
+
+    // Main loop (note that loop index goes through segments). Unroll 6-wide
+    for (int i = 0; i < iterations; ++i)
+    {
+        // Load vector elements to registers
+        int16x4_t v11 = vld1_s16(inputArray1);
+        int16x4_t v12 = vld1_s16(inputArray1 + 4);
+        int16x4_t v13 = vld1_s16(inputArray1 + 8);
+        int16x4_t v14 = vld1_s16(inputArray1 + 12);
+        int16x4_t v15 = vld1_s16(inputArray1 + 16);
+        int16x4_t v16 = vld1_s16(inputArray1 + 20);
+        int16x4_t v21 = vld1_s16(inputArray2);
+        int16x4_t v22 = vld1_s16(inputArray2 + 4);
+        int16x4_t v23 = vld1_s16(inputArray2 + 8);
+        int16x4_t v24 = vld1_s16(inputArray2 + 12);
+        int16x4_t v25 = vld1_s16(inputArray2 + 16);
+        int16x4_t v26 = vld1_s16(inputArray2 + 20);
+
+        partialSum1 = vmlal_s16(partialSum1, v11, v21);
+        partialSum2 = vmlal_s16(partialSum2, v12, v22);
+        partialSum3 = vmlal_s16(partialSum3, v13, v23);
+        partialSum4 = vmlal_s16(partialSum4, v14, v24);
+        partialSum5 = vmlal_s16(partialSum5, v15, v25);
+        partialSum6 = vmlal_s16(partialSum6, v16, v26);
+
+        inputArray1 += elementsPerIteration;
+        inputArray2 += elementsPerIteration;
+    }
+
+	// Now sum up the results of the 6 partial sums from the loop
+    int32x4_t partialSumsNeon = vaddq_s32(partialSum1, partialSum2);
+    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum3);
+    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum4);
+    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum5);
+    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum6);
+
+	// Armv8 instruction to sum up all the elements into a single scalar
+	int result = vaddvq_s32(partialSumsNeon);
+
+	// Calculate the tail
+	int tailLength = len % elementsPerIteration;
+	while (tailLength--)
+	{
+		result += *inputArray1 * *inputArray2;
+		inputArray1++;
+		inputArray2++;
+	}
+
+    return result;
+}
+
 int dotProductNeon_with_SMLAL2_2wide(short* inputArray1, short* inputArray2, short len)
 {
     const int elementsPerIteration = 8;
@@ -274,69 +337,6 @@ int dotProductNeon_with_SMLAL2_4wide(short* inputArray1, short* inputArray2, sho
     int32x4_t partialSumsNeon = vaddq_s32(partialSum1Low, partialSum1High);
     partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum2Low);
     partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum2High);
-
-	// Armv8 instruction to sum up all the elements into a single scalar
-	int result = vaddvq_s32(partialSumsNeon);
-
-	// Calculate the tail
-	int tailLength = len % elementsPerIteration;
-	while (tailLength--)
-	{
-		result += *inputArray1 * *inputArray2;
-		inputArray1++;
-		inputArray2++;
-	}
-
-    return result;
-}
-
-int dotProductNeon6(short* inputArray1, short* inputArray2, short len)
-{
-    const int elementsPerIteration = 24;
-    int iterations = len / elementsPerIteration;
-
-    // 4-element vectors of zeroes to accumulate partial results within the unrolled loop
-    int32x4_t partialSum1 = vdupq_n_s32(0);
-    int32x4_t partialSum2 = vdupq_n_s32(0);
-    int32x4_t partialSum3 = vdupq_n_s32(0);
-    int32x4_t partialSum4 = vdupq_n_s32(0);
-    int32x4_t partialSum5 = vdupq_n_s32(0);
-    int32x4_t partialSum6 = vdupq_n_s32(0);
-
-    // Main loop (note that loop index goes through segments). Unroll 6-wide
-    for (int i = 0; i < iterations; ++i)
-    {
-        // Load vector elements to registers
-        int16x4_t v11 = vld1_s16(inputArray1);
-        int16x4_t v12 = vld1_s16(inputArray1 + 4);
-        int16x4_t v13 = vld1_s16(inputArray1 + 8);
-        int16x4_t v14 = vld1_s16(inputArray1 + 12);
-        int16x4_t v15 = vld1_s16(inputArray1 + 16);
-        int16x4_t v16 = vld1_s16(inputArray1 + 20);
-        int16x4_t v21 = vld1_s16(inputArray2);
-        int16x4_t v22 = vld1_s16(inputArray2 + 4);
-        int16x4_t v23 = vld1_s16(inputArray2 + 8);
-        int16x4_t v24 = vld1_s16(inputArray2 + 12);
-        int16x4_t v25 = vld1_s16(inputArray2 + 16);
-        int16x4_t v26 = vld1_s16(inputArray2 + 20);
-
-        partialSum1 = vmlal_s16(partialSum1, v11, v21);
-        partialSum2 = vmlal_s16(partialSum2, v12, v22);
-        partialSum3 = vmlal_s16(partialSum3, v13, v23);
-        partialSum4 = vmlal_s16(partialSum4, v14, v24);
-        partialSum5 = vmlal_s16(partialSum5, v15, v25);
-        partialSum6 = vmlal_s16(partialSum6, v16, v26);
-
-        inputArray1 += elementsPerIteration;
-        inputArray2 += elementsPerIteration;
-    }
-
-	// Now sum up the results of the 6 partial sums from the loop
-    int32x4_t partialSumsNeon = vaddq_s32(partialSum1, partialSum2);
-    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum3);
-    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum4);
-    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum5);
-    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum6);
 
 	// Armv8 instruction to sum up all the elements into a single scalar
 	int result = vaddvq_s32(partialSumsNeon);

--- a/app/src/main/cpp/DotProd.cpp
+++ b/app/src/main/cpp/DotProd.cpp
@@ -194,48 +194,86 @@ int dotProductNeon4(short* inputArray1, short* inputArray2, short len)
     return result;
 }
 
-int dotProductNeon5(short* inputArray1, short* inputArray2, short len)
+int dotProductNeon_with_SMLAL2_2wide(short* inputArray1, short* inputArray2, short len)
 {
-    const int elementsPerIteration = 20;
+    const int elementsPerIteration = 8;
     int iterations = len / elementsPerIteration;
 
-    // 4-element vectors of zeroes to accumulate partial results within the unrolled loop
-    int32x4_t partialSum1 = vdupq_n_s32(0);
-    int32x4_t partialSum2 = vdupq_n_s32(0);
-    int32x4_t partialSum3 = vdupq_n_s32(0);
-    int32x4_t partialSum4 = vdupq_n_s32(0);
-    int32x4_t partialSum5 = vdupq_n_s32(0);
+    // 4-element vectors of zeroes to accumulate the result
+    int32x4_t partialSumLow = vdupq_n_s32(0);
+    int32x4_t partialSumHigh = vdupq_n_s32(0);
 
-    // Main loop (note that loop index goes through segments). Unroll 5-wide
+    // Main loop, unrolled 4-wide
     for (int i = 0; i < iterations; ++i)
     {
         // Load vector elements to registers
-        int16x4_t v11 = vld1_s16(inputArray1);
-        int16x4_t v12 = vld1_s16(inputArray1 + 4);
-        int16x4_t v13 = vld1_s16(inputArray1 + 8);
-        int16x4_t v14 = vld1_s16(inputArray1 + 12);
-        int16x4_t v15 = vld1_s16(inputArray1 + 16);
-        int16x4_t v21 = vld1_s16(inputArray2);
-        int16x4_t v22 = vld1_s16(inputArray2 + 4);
-        int16x4_t v23 = vld1_s16(inputArray2 + 8);
-        int16x4_t v24 = vld1_s16(inputArray2 + 12);
-        int16x4_t v25 = vld1_s16(inputArray2 + 16);
+		// Comparing to SMLAL variant, we're loading 128-bit vectors here (8x short int)
+		// and using SMLAL2 (vmlal_high_s16) to calculate dot product for the upper half
+		// This way, we're doing only half of the loads comparing to dotProductNeon2
+        int16x8_t v1 = vld1q_s16(inputArray1);
+        int16x8_t v2 = vld1q_s16(inputArray2);
 
-        partialSum1 = vmlal_s16(partialSum1, v11, v21);
-        partialSum2 = vmlal_s16(partialSum2, v12, v22);
-        partialSum3 = vmlal_s16(partialSum3, v13, v23);
-        partialSum4 = vmlal_s16(partialSum4, v14, v24);
-        partialSum5 = vmlal_s16(partialSum5, v15, v25);
+		partialSumLow  = vmlal_s16(partialSumLow, vget_low_s16(v1), vget_low_s16(v2));
+		partialSumHigh = vmlal_high_s16(partialSumHigh, v1, v2);
 
         inputArray1 += elementsPerIteration;
         inputArray2 += elementsPerIteration;
     }
 
-	// Now sum up the results of the 5 partial sums from the loop
-    int32x4_t partialSumsNeon = vaddq_s32(partialSum1, partialSum2);
-    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum3);
-    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum4);
-    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum5);
+	// Now sum up the results of the 2 partial sums from the loop
+    int32x4_t partialSumsNeon = vaddq_s32(partialSumLow, partialSumHigh);
+
+	// Armv8 instruction to sum up all the elements into a single scalar
+	int result = vaddvq_s32(partialSumsNeon);
+
+	// Calculate the tail
+	int tailLength = len % elementsPerIteration;
+	while (tailLength--)
+	{
+		result += *inputArray1 * *inputArray2;
+		inputArray1++;
+		inputArray2++;
+	}
+
+    return result;
+}
+
+int dotProductNeon_with_SMLAL2_4wide(short* inputArray1, short* inputArray2, short len)
+{
+    const int elementsPerIteration = 16;
+    int iterations = len / elementsPerIteration;
+
+    // 4-element vectors of zeroes to accumulate the result
+    int32x4_t partialSum1Low = vdupq_n_s32(0);
+    int32x4_t partialSum1High = vdupq_n_s32(0);
+    int32x4_t partialSum2Low = vdupq_n_s32(0);
+    int32x4_t partialSum2High = vdupq_n_s32(0);
+
+    // Main loop, unrolled 4-wide
+    for (int i = 0; i < iterations; ++i)
+    {
+        // Load vector elements to registers
+		// Comparing to SMLAL variant, we're loading 128-bit vectors here (8x short int)
+		// and using SMLAL2 (vmlal_high_s16) to calculate dot product for the upper half
+		// This way, we're doing only half of the loads comparing to dotProductNeon4
+        int16x8_t v11 = vld1q_s16(inputArray1);
+        int16x8_t v12 = vld1q_s16(inputArray1 + 8);
+        int16x8_t v21 = vld1q_s16(inputArray2);
+        int16x8_t v22 = vld1q_s16(inputArray2 + 8);
+
+		partialSum1Low  = vmlal_s16(partialSum1Low, vget_low_s16(v11), vget_low_s16(v21));
+		partialSum1High = vmlal_high_s16(partialSum1High, v11, v21);
+		partialSum2Low  = vmlal_s16(partialSum2Low, vget_low_s16(v12), vget_low_s16(v22));
+		partialSum2High = vmlal_high_s16(partialSum2High, v12, v22);
+
+        inputArray1 += elementsPerIteration;
+        inputArray2 += elementsPerIteration;
+    }
+
+	// Now sum up the results of the 4 partial sums from the loop
+    int32x4_t partialSumsNeon = vaddq_s32(partialSum1Low, partialSum1High);
+    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum2Low);
+    partialSumsNeon = vaddq_s32(partialSumsNeon, partialSum2High);
 
 	// Armv8 instruction to sum up all the elements into a single scalar
 	int result = vaddvq_s32(partialSumsNeon);

--- a/app/src/main/cpp/DotProd.h
+++ b/app/src/main/cpp/DotProd.h
@@ -5,5 +5,6 @@ int dotProductNeon(short* inputArray1, short* inputArray2, short len);
 int dotProductNeon2(short* inputArray1, short* inputArray2, short len);
 int dotProductNeon3(short* inputArray1, short* inputArray2, short len);
 int dotProductNeon4(short* inputArray1, short* inputArray2, short len);
-int dotProductNeon5(short* inputArray1, short* inputArray2, short len);
 int dotProductNeon6(short* inputArray1, short* inputArray2, short len);
+int dotProductNeon_with_SMLAL2_2wide(short* inputArray1, short* inputArray2, short len);
+int dotProductNeon_with_SMLAL2_4wide(short* inputArray1, short* inputArray2, short len);

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -119,16 +119,6 @@ Java_com_example_neonintrinsics_MainActivity_stringFromJNI(
     auto elapsedMsTimeNeon4 = timer.elapsedMs();
     ATrace_endSection();
 
-    ATrace_beginSection("dotProductNeon5");
-    int lastResultNeon5 = 0;
-    timer.reset();
-    for (int i = 0; i < trials; i++)
-    {
-        lastResultNeon5 = dotProductNeon5(ramp1, ramp2, rampLength);
-    }
-    auto elapsedMsTimeNeon5 = timer.elapsedMs();
-    ATrace_endSection();
-
     ATrace_beginSection("dotProductNeon6");
     int lastResultNeon6 = 0;
     timer.reset();
@@ -137,6 +127,26 @@ Java_com_example_neonintrinsics_MainActivity_stringFromJNI(
         lastResultNeon6 = dotProductNeon6(ramp1, ramp2, rampLength);
     }
     auto elapsedMsTimeNeon6 = timer.elapsedMs();
+    ATrace_endSection();
+
+    ATrace_beginSection("dotProductNeon_with_SMLAL2_2wide");
+    int lastResultNeon_with_SMLAL2_2wide = 0;
+    timer.reset();
+    for (int i = 0; i < trials; i++)
+    {
+        lastResultNeon_with_SMLAL2_2wide = dotProductNeon_with_SMLAL2_2wide(ramp1, ramp2, rampLength);
+    }
+    auto elapsedMsTimeNeon_with_SMLAL2_2wide = timer.elapsedMs();
+    ATrace_endSection();
+
+    ATrace_beginSection("dotProductNeon_with_SMLAL2_4wide");
+    int lastResultNeon_with_SMLAL2_4wide = 0;
+    timer.reset();
+    for (int i = 0; i < trials; i++)
+    {
+        lastResultNeon_with_SMLAL2_4wide = dotProductNeon_with_SMLAL2_4wide(ramp1, ramp2, rampLength);
+    }
+    auto elapsedMsTimeNeon_with_SMLAL2_4wide = timer.elapsedMs();
     ATrace_endSection();
 
     // Clean up
@@ -161,10 +171,13 @@ Java_com_example_neonintrinsics_MainActivity_stringFromJNI(
         \n\n----==== NEON 4x unrolling ====----\n\
         Result: %d\
         \nelapsedMs time: %f ms\
-        \n\n----==== NEON 5x unrolling ====----\n\
+        \n\n----==== NEON 6x unrolling ====----\n\
         Result: %d\
         \nelapsedMs time: %f ms\
-        \n\n----==== NEON 6x unrolling ====----\n\
+        \n\n----==== NEON SMLAL+SMLAL2 2-wide ====----\n\
+        Result: %d\
+        \nelapsedMs time: %f ms\
+        \n\n----==== NEON SMLAL+SMLAL2 4-wide ====----\n\
         Result: %d\
         \nelapsedMs time: %f ms",
         lastResult, elapsedMsTime,
@@ -172,8 +185,9 @@ Java_com_example_neonintrinsics_MainActivity_stringFromJNI(
         lastResultNeon2, elapsedMsTimeNeon2,
         lastResultNeon3, elapsedMsTimeNeon3,
         lastResultNeon4, elapsedMsTimeNeon4,
-        lastResultNeon5, elapsedMsTimeNeon5,
-        lastResultNeon6, elapsedMsTimeNeon6);
+        lastResultNeon6, elapsedMsTimeNeon6,
+        lastResultNeon_with_SMLAL2_2wide, elapsedMsTimeNeon_with_SMLAL2_2wide,
+        lastResultNeon_with_SMLAL2_4wide, elapsedMsTimeNeon_with_SMLAL2_4wide);
 
     return env->NewStringUTF(resultsString);
 }


### PR DESCRIPTION
New Neon implementation: use SMLAL and SMLAL2 and spare half of the loads (2wide and 4wide)

Remove 5x loop unroll